### PR TITLE
fix: another attempt to improve material/lighting in edit mode

### DIFF
--- a/src/objects/SerializableModel.ts
+++ b/src/objects/SerializableModel.ts
@@ -21,6 +21,7 @@ import KaitaiStream from "../kaitai/runtime/KaitaiStream";
 import {
   applyDiffToOffsetTable,
   assignPublicProperties,
+  clamp,
   computeAverageVertex,
   ensureOffsetTableAligned,
   getPixelsFromCanvasImageSource,
@@ -397,9 +398,6 @@ export default class SerializableModel {
       primitiveWrapper.body = primitive;
       primitive.primitiveStartIndex = currentPrimitiveTriangleIndex;
       primitive.primitiveLength = triangleIndexCount;
-      primitive.backfaceCulling = Number(this.params.backfaceCulling);
-      primitive.materialType =
-        SilentHillModel.PrimitiveHeader.MaterialType.MATTE_PLUS;
       primitive.samplerStates = [/*0x03, 0x03,*/ 0x01, 0x01, 0x02, 0x02];
       currentPrimitiveTriangleIndex += triangleIndexCount;
 
@@ -805,7 +803,7 @@ export default class SerializableModel {
         mesh.skeleton.bones[sourceBone].updateMatrixWorld();
         const transform =
           model.modelData.initialMatrices[
-            targetBone ?? bonemapCollapseTarget
+          targetBone ?? bonemapCollapseTarget
           ] ?? model.modelData.initialMatrices[bonemapCollapseTarget];
         objectSpaceMatrix = transformationMatrixToMat4(transform).invert();
         boneSpaceMatrices.set(targetBone, objectSpaceMatrix);
@@ -824,9 +822,9 @@ export default class SerializableModel {
           vector.z,
         ];
         vertexData.normals = [
-          normalVector.x * MIN_SIGNED_INT,
-          normalVector.y * MIN_SIGNED_INT,
-          normalVector.z * MIN_SIGNED_INT,
+          clamp(normalVector.x * MIN_SIGNED_INT, -0x8000, 0x8000 - 1),
+          clamp(normalVector.y * MIN_SIGNED_INT, -0x8000, 0x8000 - 1),
+          clamp(normalVector.z * MIN_SIGNED_INT, -0x8000, 0x8000 - 1),
         ];
 
         for (let pairIndex = 1; pairIndex <= 3; pairIndex++) {
@@ -856,13 +854,13 @@ export default class SerializableModel {
               mat4ToTransformationMatrix(
                 transformationMatrixToMat4(
                   model.modelData.initialMatrices[child] ??
-                    model.modelData.initialMatrices[bonemapCollapseTarget]
+                  model.modelData.initialMatrices[bonemapCollapseTarget]
                 )
                   .invert()
                   .multiply(
                     transformationMatrixToMat4(
                       model.modelData.initialMatrices[parent] ??
-                        model.modelData.initialMatrices[bonemapCollapseTarget]
+                      model.modelData.initialMatrices[bonemapCollapseTarget]
                     )
                   ),
                 new SilentHillModel.TransformationMatrix(
@@ -911,11 +909,11 @@ export default class SerializableModel {
           vertexData.boneWeight2,
           vertexData.boneWeight3,
         ] = [
-          boneWeights[skinIndex],
-          boneAndPairs[1] ? boneWeights[skinIndex + 1] : 0,
-          boneAndPairs[2] ? boneWeights[skinIndex + 2] : 0,
-          boneAndPairs[3] ? boneWeights[skinIndex + 3] : 0,
-        ];
+            boneWeights[skinIndex],
+            boneAndPairs[1] ? boneWeights[skinIndex + 1] : 0,
+            boneAndPairs[2] ? boneWeights[skinIndex + 2] : 0,
+            boneAndPairs[3] ? boneWeights[skinIndex + 3] : 0,
+          ];
         const sum =
           vertexData.boneWeight0 +
           vertexData.boneWeight1 +
@@ -928,11 +926,11 @@ export default class SerializableModel {
             vertexData.boneWeight2,
             vertexData.boneWeight3,
           ] = [
-            vertexData.boneWeight0 / sum,
-            vertexData.boneWeight1 / sum,
-            vertexData.boneWeight2 / sum,
-            vertexData.boneWeight3 / sum,
-          ];
+              vertexData.boneWeight0 / sum,
+              vertexData.boneWeight1 / sum,
+              vertexData.boneWeight2 / sum,
+              vertexData.boneWeight3 / sum,
+            ];
         } else {
           [
             vertexData.boneWeight0,
@@ -983,9 +981,9 @@ export default class SerializableModel {
           vector.z,
         ];
         vertexData.normals = [
-          normalVector.x * MIN_SIGNED_INT,
-          normalVector.y * MIN_SIGNED_INT,
-          normalVector.z * MIN_SIGNED_INT,
+          clamp(normalVector.x * MIN_SIGNED_INT, -0x8000, 0x8000 - 1),
+          clamp(normalVector.y * MIN_SIGNED_INT, -0x8000, 0x8000 - 1),
+          clamp(normalVector.z * MIN_SIGNED_INT, -0x8000, 0x8000 - 1),
         ];
         vertexData.boneWeight0 = 1;
         vertexData.boneWeight1 = 0;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,6 +49,8 @@ export const mod = (n: number, m: number) => {
   return ((n % m) + m) % m;
 };
 
+export const clamp = (x: number, min: number, max: number) => Math.max(min, Math.min(max, x))
+
 export const findLastNotExceeding = (
   array: readonly number[],
   target: number
@@ -222,13 +224,13 @@ export function exportModel(
     object,
     typeof filenameOrCallback === "string"
       ? (result) => {
-          if (result instanceof ArrayBuffer) {
-            saveArrayBuffer(result, `${filenameOrCallback}.glb`);
-          } else {
-            const output = JSON.stringify(result, null, 2);
-            saveString(output, `${filenameOrCallback}.gltf`);
-          }
+        if (result instanceof ArrayBuffer) {
+          saveArrayBuffer(result, `${filenameOrCallback}.glb`);
+        } else {
+          const output = JSON.stringify(result, null, 2);
+          saveString(output, `${filenameOrCallback}.gltf`);
         }
+      }
       : filenameOrCallback,
     (error) => {
       logger.warn("Could not export the scene. An error occurred: ", error);


### PR DESCRIPTION
when using edit mode to import a gltf model, a normal vector with an exact value of -1 in any of its components will be flipped in the result.

mdl stores its normals as 16-bit signed integers (in the range `[-32768, 32767]`), and to get it in the range `[-1, 1)` we divide by -0x8000 (the minimum 16-bit signed integer). so to create new mdl files, we are multiplying by -0x8000, but this breaks at -1 because the unsigned value `32768` maps to the signed value of `-32768`.

```js
const buffer = new ArrayBuffer(6);
const view = new DataView(buffer);
view.setInt16(0, -0.999 * -0x8000);
view.setInt16(2, -1 * -0x8000);
console.log(view.getInt16(0) / -0x8000);
console.log(view.getInt16(2) / -0x8000);
```

gives
```
-0.998992919921875 
1
```

this PR also deletes some lines that attempt to modify backface culling or material type on primitives, for now. hope is that this should increase accuracy for making changes to existing sh2 models, but i hope to add more support for changing these fields at some point